### PR TITLE
We need to support the possibility to skip queue declaration.

### DIFF
--- a/amqp/queue/rabbitmq.go
+++ b/amqp/queue/rabbitmq.go
@@ -41,6 +41,7 @@ type RabbitMQQueue struct {
 	AutoDelete  bool
 	Exclusive   bool
 	NoWait      bool
+	SkipDeclare bool
 	ProcessFunc ProcessFunc
 }
 

--- a/amqp/rabbitmq.go
+++ b/amqp/rabbitmq.go
@@ -26,6 +26,12 @@ type RabbitMQClient struct {
 // Connect takes care of "on connect" specific tasks.
 func (c *RabbitMQClient) Connect() error {
 	for _, q := range c.Cfg.Queues {
+		if q.SkipDeclare {
+			c.Log.Info(fmt.Sprintf("Skipping declaration of queue: %s", q.Name))
+
+			continue
+		}
+
 		// See https://www.rabbitmq.com/amqp-0-9-1-reference.html for
 		// more information about the arguments.
 		_, err := c.Channel.QueueDeclare(

--- a/amqp/rabbitmq_test.go
+++ b/amqp/rabbitmq_test.go
@@ -575,18 +575,20 @@ func TestQueueConsuming(t *testing.T) {
 func TestRabbitMQClientConnectQueueSkipDeclareSuccess(t *testing.T) {
 	l, w := helper.NewTestLogging()
 
+	queues := []queue.RabbitMQQueue{
+		{
+			Name:        "test",
+			SkipDeclare: true,
+		},
+		{
+			Name:        "hax",
+			SkipDeclare: true,
+		},
+	}
+
 	client := &amqp.RabbitMQClient{
 		Cfg: amqp.RabbitMQConfig{
-			Queues: []queue.RabbitMQQueue{
-				{
-					Name:        "test",
-					SkipDeclare: true,
-				},
-				{
-					Name:        "hax",
-					SkipDeclare: true,
-				},
-			},
+			Queues: queues,
 		},
 		Log: l,
 	}
@@ -600,12 +602,12 @@ func TestRabbitMQClientConnectQueueSkipDeclareSuccess(t *testing.T) {
 		t.Fatal("expected", 2, "got", logsLen)
 	}
 
-	for k, v := range []string{"test", "hax"} {
+	for k, q := range queues {
 		helper.ValidateLogEntry(
 			t,
 			w.Buffer[k],
 			logging.InfoLogLevel,
-			fmt.Sprintf("Skipping declaration of queue: %s", v),
+			fmt.Sprintf("Skipping declaration of queue: %s", q.Name),
 		)
 	}
 }


### PR DESCRIPTION
The queue declaration logic is very limited in this code. It doesn't
really scale when it comes to configuring dead lettering, etc.

Adding support for skipping the queue declaration on per queue
definition.

We might add a more robust and declarative queue definition support in
the future.