### PR TITLE
Changed log level of Connecting to <URI> to debug

### DIFF
--- a/amqp/rabbitmq.go
+++ b/amqp/rabbitmq.go
@@ -263,7 +263,7 @@ func (a *RabbitMQ) Connect() (err error) {
 		a.Connecting = false
 	}(a)
 
-	a.Log.Info(fmt.Sprintf("Connecting to RabbitMQ at %s...", a.Cfg.URL))
+	a.Log.Debug(fmt.Sprintf("Connecting to RabbitMQ at %s...", a.Cfg.URL))
 
 	a.Client, err = a.Dial.Dial()
 	if err != nil {

--- a/amqp/rabbitmq_test.go
+++ b/amqp/rabbitmq_test.go
@@ -154,7 +154,7 @@ func TestRabbitMQDialDialFailure(t *testing.T) {
 	helper.ValidateLogEntry(
 		t,
 		w.Buffer[0],
-		logging.InfoLogLevel,
+		logging.DebugLogLevel,
 		fmt.Sprintf("Connecting to RabbitMQ at %s...", cfg.URL),
 	)
 
@@ -204,7 +204,7 @@ func TestRabbitMQClientConnectFailure(t *testing.T) {
 	helper.ValidateLogEntry(
 		t,
 		w.Buffer[0],
-		logging.InfoLogLevel,
+		logging.DebugLogLevel,
 		fmt.Sprintf("Connecting to RabbitMQ at %s...", cfg.URL),
 	)
 
@@ -253,7 +253,7 @@ func TestRabbitMQClientConnectSuccess(t *testing.T) {
 	helper.ValidateLogEntry(
 		t,
 		w.Buffer[0],
-		logging.InfoLogLevel,
+		logging.DebugLogLevel,
 		fmt.Sprintf("Connecting to RabbitMQ at %s...", cfg.URL),
 	)
 }
@@ -332,7 +332,7 @@ func TestRabbitMQClientReconnectSuccess(t *testing.T) {
 	helper.ValidateLogEntry(
 		t,
 		w.Buffer[1],
-		logging.InfoLogLevel,
+		logging.DebugLogLevel,
 		fmt.Sprintf("Connecting to RabbitMQ at %s...", cfg.URL),
 	)
 }
@@ -382,7 +382,7 @@ func TestRabbitMQClientReconnectReConsumeSuccess(t *testing.T) {
 	helper.ValidateLogEntry(
 		t,
 		w.Buffer[1],
-		logging.InfoLogLevel,
+		logging.DebugLogLevel,
 		fmt.Sprintf("Connecting to RabbitMQ at %s...", cfg.URL),
 	)
 


### PR DESCRIPTION
Since the URI to the broker contains username and password in cleartext, we should be very careful logging it since it probably ends up in Kibana. Changed to DEBUG level, but maybe consider removing the URI or cleaning the sensitive parts out before logging?