### PR TITLE
Introduced header support in AMQPDelivery with impl

### DIFF
--- a/amqp/amqp.go
+++ b/amqp/amqp.go
@@ -5,6 +5,8 @@ type AMQP interface {
 	Connect() error
 	Publish(string, []byte) error
 	PublishOnExchange(string, []byte) error
+	PublishWithHeaders(string, []byte, map[string]interface{}) error
+	PublishOnExchangeWithHeaders(string, []byte, map[string]interface{}) error
 	Consume() error
 	Ping() error
 	Close() error
@@ -17,6 +19,8 @@ type AMQPClient interface {
 	Close() error
 	Publish(string, []byte) error
 	PublishOnExchange(string, []byte) error
+	PublishWithHeaders(string, []byte, map[string]interface{}) error
+	PublishOnExchangeWithHeaders(string, []byte, map[string]interface{}) error
 	Consume() error
 }
 

--- a/amqp/mock_amqp/mock_amqp.go
+++ b/amqp/mock_amqp/mock_amqp.go
@@ -5,8 +5,8 @@
 package mock_amqp
 
 import (
-	x "github.com/inteleon/go-amqp/amqp"
 	gomock "github.com/golang/mock/gomock"
+	x "github.com/inteleon/go-amqp/amqp"
 	reflect "reflect"
 )
 

--- a/amqp/mock_amqp/mock_amqp.go
+++ b/amqp/mock_amqp/mock_amqp.go
@@ -5,8 +5,8 @@
 package mock_amqp
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	x "github.com/inteleon/go-amqp/amqp"
+	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 )
 
@@ -73,6 +73,34 @@ func (m *MockAMQP) PublishOnExchange(arg0 string, arg1 []byte) error {
 func (mr *MockAMQPMockRecorder) PublishOnExchange(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishOnExchange", reflect.TypeOf((*MockAMQP)(nil).PublishOnExchange), arg0, arg1)
+}
+
+// PublishWithHeaders mocks base method
+func (m *MockAMQP) PublishWithHeaders(arg0 string, arg1 []byte, arg2 map[string]interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PublishWithHeaders", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PublishWithHeaders indicates an expected call of PublishWithHeaders
+func (mr *MockAMQPMockRecorder) PublishWithHeaders(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishWithHeaders", reflect.TypeOf((*MockAMQP)(nil).PublishWithHeaders), arg0, arg1, arg2)
+}
+
+// PublishOnExchangeWithHeaders mocks base method
+func (m *MockAMQP) PublishOnExchangeWithHeaders(arg0 string, arg1 []byte, arg2 map[string]interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PublishOnExchangeWithHeaders", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PublishOnExchangeWithHeaders indicates an expected call of PublishOnExchangeWithHeaders
+func (mr *MockAMQPMockRecorder) PublishOnExchangeWithHeaders(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishOnExchangeWithHeaders", reflect.TypeOf((*MockAMQP)(nil).PublishOnExchangeWithHeaders), arg0, arg1, arg2)
 }
 
 // Consume mocks base method
@@ -208,6 +236,34 @@ func (m *MockAMQPClient) PublishOnExchange(arg0 string, arg1 []byte) error {
 func (mr *MockAMQPClientMockRecorder) PublishOnExchange(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishOnExchange", reflect.TypeOf((*MockAMQPClient)(nil).PublishOnExchange), arg0, arg1)
+}
+
+// PublishWithHeaders mocks base method
+func (m *MockAMQPClient) PublishWithHeaders(arg0 string, arg1 []byte, arg2 map[string]interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PublishWithHeaders", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PublishWithHeaders indicates an expected call of PublishWithHeaders
+func (mr *MockAMQPClientMockRecorder) PublishWithHeaders(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishWithHeaders", reflect.TypeOf((*MockAMQPClient)(nil).PublishWithHeaders), arg0, arg1, arg2)
+}
+
+// PublishOnExchangeWithHeaders mocks base method
+func (m *MockAMQPClient) PublishOnExchangeWithHeaders(arg0 string, arg1 []byte, arg2 map[string]interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PublishOnExchangeWithHeaders", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PublishOnExchangeWithHeaders indicates an expected call of PublishOnExchangeWithHeaders
+func (mr *MockAMQPClientMockRecorder) PublishOnExchangeWithHeaders(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishOnExchangeWithHeaders", reflect.TypeOf((*MockAMQPClient)(nil).PublishOnExchangeWithHeaders), arg0, arg1, arg2)
 }
 
 // Consume mocks base method

--- a/amqp/queue/mock_queue/mock_queue.go
+++ b/amqp/queue/mock_queue/mock_queue.go
@@ -77,7 +77,7 @@ func (mr *MockAMQPDeliveryMockRecorder) Nack(arg0, arg1 interface{}) *gomock.Cal
 }
 
 // SetHeader mocks base method
-func (m *MockAMQPDelivery) SetHeader(key, value string) error {
+func (m *MockAMQPDelivery) SetHeader(key string, value interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetHeader", key, value)
 	ret0, _ := ret[0].(error)
@@ -91,11 +91,12 @@ func (mr *MockAMQPDeliveryMockRecorder) SetHeader(key, value interface{}) *gomoc
 }
 
 // GetHeader mocks base method
-func (m *MockAMQPDelivery) GetHeader(key string) string {
+func (m *MockAMQPDelivery) GetHeader(key string) (interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHeader", key)
-	ret0, _ := ret[0].(string)
-	return ret0
+	ret0, _ := ret[0].(interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetHeader indicates an expected call of GetHeader

--- a/amqp/queue/mock_queue/mock_queue.go
+++ b/amqp/queue/mock_queue/mock_queue.go
@@ -76,6 +76,34 @@ func (mr *MockAMQPDeliveryMockRecorder) Nack(arg0, arg1 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nack", reflect.TypeOf((*MockAMQPDelivery)(nil).Nack), arg0, arg1)
 }
 
+// SetHeader mocks base method
+func (m *MockAMQPDelivery) SetHeader(key, value string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetHeader", key, value)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetHeader indicates an expected call of SetHeader
+func (mr *MockAMQPDeliveryMockRecorder) SetHeader(key, value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHeader", reflect.TypeOf((*MockAMQPDelivery)(nil).SetHeader), key, value)
+}
+
+// GetHeader mocks base method
+func (m *MockAMQPDelivery) GetHeader(key string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHeader", key)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetHeader indicates an expected call of GetHeader
+func (mr *MockAMQPDeliveryMockRecorder) GetHeader(key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeader", reflect.TypeOf((*MockAMQPDelivery)(nil).GetHeader), key)
+}
+
 // MockAMQPConsumer is a mock of AMQPConsumer interface
 type MockAMQPConsumer struct {
 	ctrl     *gomock.Controller

--- a/amqp/queue/queue.go
+++ b/amqp/queue/queue.go
@@ -8,6 +8,8 @@ type AMQPDelivery interface {
 	Payload() ([]byte, error)
 	Ack(bool) error
 	Nack(bool, bool) error
+	SetHeader(key, value string) error
+	GetHeader(key string) (string, error)
 }
 
 type AMQPConsumer interface {

--- a/amqp/queue/queue.go
+++ b/amqp/queue/queue.go
@@ -8,8 +8,8 @@ type AMQPDelivery interface {
 	Payload() ([]byte, error)
 	Ack(bool) error
 	Nack(bool, bool) error
-	SetHeader(key, value string) error
-	GetHeader(key string) (string, error)
+	SetHeader(key string, value interface{}) error
+	GetHeader(key string) (interface{}, error)
 }
 
 type AMQPConsumer interface {

--- a/amqp/queue/rabbitmq.go
+++ b/amqp/queue/rabbitmq.go
@@ -34,7 +34,7 @@ func (d *RabbitMQDelivery) Nack(multiple, requeue bool) error {
 	return d.Delivery.Nack(multiple, requeue)
 }
 
-func (d *RabbitMQDelivery) SetHeader(key, value string) error {
+func (d *RabbitMQDelivery) SetHeader(key string, value interface{}) error {
 	if key == "" {
 		return fmt.Errorf("setting header with empty key is not allowed")
 	}
@@ -45,12 +45,12 @@ func (d *RabbitMQDelivery) SetHeader(key, value string) error {
 	return nil
 }
 
-func (d *RabbitMQDelivery) GetHeader(key string) (string, error) {
+func (d *RabbitMQDelivery) GetHeader(key string) (interface{}, error) {
 	header := d.Delivery.Headers[key]
-	if value, ok := header.(string); ok {
-		return value, nil
+	if header != nil {
+		return header, nil
 	}
-	return "", fmt.Errorf("header %v is not present on Delivery", key)
+	return nil, fmt.Errorf("header %v is not present on Delivery", key)
 }
 
 // RabbitMQQueue defines a single queue that we will connect to (and declare if needed).

--- a/amqp/queue/rabbitmq.go
+++ b/amqp/queue/rabbitmq.go
@@ -34,6 +34,25 @@ func (d *RabbitMQDelivery) Nack(multiple, requeue bool) error {
 	return d.Delivery.Nack(multiple, requeue)
 }
 
+func (d *RabbitMQDelivery) SetHeader(key, value string) error {
+	if key == "" {
+		return fmt.Errorf("setting header with empty key is not allowed")
+	}
+	if d.Delivery.Headers == nil {
+		d.Delivery.Headers = make(map[string]interface{})
+	}
+	d.Delivery.Headers[key] = value
+	return nil
+}
+
+func (d *RabbitMQDelivery) GetHeader(key string) (string, error) {
+	header := d.Delivery.Headers[key]
+	if value, ok := header.(string); ok {
+		return value, nil
+	}
+	return "", fmt.Errorf("header %v is not present on Delivery", key)
+}
+
 // RabbitMQQueue defines a single queue that we will connect to (and declare if needed).
 // See https://www.rabbitmq.com/amqp-0-9-1-reference.html for
 // more information about the arguments when declaring queues.

--- a/amqp/queue/rabbitmq_test.go
+++ b/amqp/queue/rabbitmq_test.go
@@ -89,3 +89,23 @@ func TestFullFlow(t *testing.T) {
 		"The delivery channel has been closed! Exiting...",
 	)
 }
+
+func TestHeaders(t *testing.T) {
+	expectedVal := "some-value"
+	delivery := queue.RabbitMQDelivery{
+		Delivery: aq.Delivery{
+			Body: []byte("1337"),
+		},
+	}
+	err := delivery.SetHeader("some-key", expectedVal)
+	if err != nil {
+		t.Fatalf("unexpected error setting header")
+	}
+	val, err := delivery.GetHeader("some-key")
+	if err != nil {
+		t.Fatalf("unexpected error getting header")
+	}
+	if val != expectedVal {
+		t.Fatalf("expected %v getting header, got %v", expectedVal, val)
+	}
+}

--- a/amqp/rabbitmq.go
+++ b/amqp/rabbitmq.go
@@ -291,7 +291,7 @@ func (a *RabbitMQ) Connect() (err error) {
 	return
 }
 
-// Publish takes care of dispatching messages to RabbitMQ.
+// Publish takes care of dispatching messages to RabbitMQ using a routing key.
 func (a *RabbitMQ) Publish(routingKey string, payload []byte) error {
 	if a.Client == nil {
 		return a.clientDoesNotExist()
@@ -299,12 +299,32 @@ func (a *RabbitMQ) Publish(routingKey string, payload []byte) error {
 
 	return a.Client.Publish(routingKey, payload)
 }
+
+// PublishOnExchange takes care of dispatching messages to a named exchange on RabbitMQ.
 func (a *RabbitMQ) PublishOnExchange(exchange string, payload []byte) error {
 	if a.Client == nil {
 		return a.clientDoesNotExist()
 	}
 
 	return a.Client.PublishOnExchange(exchange, payload)
+}
+
+// PublishWithHeaders takes care of dispatching messages to RabbitMQ using a routing key with custom headers.
+func (a *RabbitMQ) PublishWithHeaders(routingKey string, payload []byte, headers map[string]interface{}) error {
+	if a.Client == nil {
+		return a.clientDoesNotExist()
+	}
+
+	return a.Client.PublishWithHeaders(routingKey, payload, headers)
+}
+
+// PublishOnExchangeWithHeaders takes care of dispatching messages to a named exchange on RabbitMQ with custom headers.
+func (a *RabbitMQ) PublishOnExchangeWithHeaders(exchange string, payload []byte, headers map[string]interface{}) error {
+	if a.Client == nil {
+		return a.clientDoesNotExist()
+	}
+
+	return a.Client.PublishOnExchangeWithHeaders(exchange, payload, headers)
 }
 
 // Consume takes care of starting up queue consumers.

--- a/amqp/rabbitmq.go
+++ b/amqp/rabbitmq.go
@@ -146,22 +146,32 @@ func (c *RabbitMQClient) Close() error {
 
 // Publish takes care of publishing a message to a single RabbitMQ queue.
 func (c *RabbitMQClient) Publish(routingKey string, payload []byte) error {
-	return c.publish(routingKey, "", payload)
+	return c.publish(routingKey, "", payload, aq.Table{})
+}
+
+// PublishWithHeaders takes care of publishing a message to a single RabbitMQ queue.
+func (c *RabbitMQClient) PublishWithHeaders(routingKey string, payload []byte, headers map[string]interface{}) error {
+	return c.publish(routingKey, "", payload, headers)
 }
 
 // PublishOnExchange takes care of publishing a message to a single RabbitMQ exchange.
 func (c *RabbitMQClient) PublishOnExchange(exchange string, payload []byte) error {
-	return c.publish("", exchange, payload)
+	return c.publish("", exchange, payload, aq.Table{})
 }
 
-func (c *RabbitMQClient) publish(routingKey, exchange string, payload []byte) error {
+// PublishOnExchangeWithHeaders takes care of publishing a message to a single RabbitMQ exchange.
+func (c *RabbitMQClient) PublishOnExchangeWithHeaders(exchange string, payload []byte, headers map[string]interface{}) error {
+	return c.publish("", exchange, payload, headers)
+}
+
+func (c *RabbitMQClient) publish(routingKey, exchange string, payload []byte, headers aq.Table) error {
 	return c.Channel.Publish(
 		exchange,
 		routingKey,
 		false, // mandatory
 		false, // immediate
 		aq.Publishing{
-			Headers:         aq.Table{},
+			Headers:         headers,
 			ContentType:     "application/json",
 			ContentEncoding: "",
 			Body:            payload,

--- a/amqp/rabbitmq_test.go
+++ b/amqp/rabbitmq_test.go
@@ -468,6 +468,30 @@ func TestRabbitMQClientPublishSuccess(t *testing.T) {
 	}
 }
 
+func TestRabbitMQClientPublishWithHeadersSuccess(t *testing.T) {
+	var client struct {
+		rabbitMQClientConnectSuccessful
+		rabbitMQClientCloseSuccessful
+		rabbitMQClientPublishSuccessful
+		rabbitMQClientConsumeSuccessful
+	}
+
+	client.t = t
+	client.ExpectedPublishRoutingKey = "hax"
+	client.ExpectedPublishExchange = ""
+	client.ExpectedPublishPayload = []byte("haxor")
+	client.ExpectedHeaders = map[string]interface{}{"key": "value"}
+
+	r := &amqp.RabbitMQ{
+		Client: &client,
+	}
+
+	publish := r.PublishWithHeaders("hax", []byte("haxor"), map[string]interface{}{"key": "value"})
+	if publish != nil {
+		t.Fatal("expected", nil, "got", publish)
+	}
+}
+
 func TestRabbitMQClientPublishOnExchangeSuccess(t *testing.T) {
 	var client struct {
 		rabbitMQClientConnectSuccessful
@@ -486,6 +510,30 @@ func TestRabbitMQClientPublishOnExchangeSuccess(t *testing.T) {
 	}
 
 	publish := r.PublishOnExchange("some.exchange", []byte("haxor"))
+	if publish != nil {
+		t.Fatal("expected", nil, "got", publish)
+	}
+}
+
+func TestRabbitMQClientPublishOnExchangeWithHeadersSuccess(t *testing.T) {
+	var client struct {
+		rabbitMQClientConnectSuccessful
+		rabbitMQClientCloseSuccessful
+		rabbitMQClientPublishSuccessful
+		rabbitMQClientConsumeSuccessful
+	}
+
+	client.t = t
+	client.ExpectedPublishRoutingKey = ""
+	client.ExpectedPublishExchange = "some.exchange"
+	client.ExpectedPublishPayload = []byte("haxor")
+	client.ExpectedHeaders = map[string]interface{}{"key": "value"}
+
+	r := &amqp.RabbitMQ{
+		Client: &client,
+	}
+
+	publish := r.PublishOnExchangeWithHeaders("some.exchange", []byte("haxor"), map[string]interface{}{"key": "value"})
 	if publish != nil {
 		t.Fatal("expected", nil, "got", publish)
 	}

--- a/amqp/rabbitmq_test.go
+++ b/amqp/rabbitmq_test.go
@@ -39,6 +39,7 @@ type rabbitMQClientPublishSuccessful struct {
 	ExpectedPublishRoutingKey string
 	ExpectedPublishExchange   string
 	ExpectedPublishPayload    []byte
+	ExpectedHeaders           map[string]interface{}
 }
 
 func (r *rabbitMQClientPublishSuccessful) Publish(routingKey string, payload []byte) (err error) {
@@ -63,6 +64,31 @@ func (r *rabbitMQClientPublishSuccessful) PublishOnExchange(exchange string, pay
 
 	return
 }
+func (r *rabbitMQClientPublishSuccessful) PublishWithHeaders(routingKey string, payload []byte, headers map[string]interface{}) (err error) {
+	if routingKey != r.ExpectedPublishRoutingKey {
+		r.t.Fatal("expected", r.ExpectedPublishRoutingKey, "got", routingKey)
+	}
+
+	if !reflect.DeepEqual(payload, r.ExpectedPublishPayload) {
+		r.t.Fatal("expected", string(r.ExpectedPublishPayload), "got", string(payload))
+	}
+
+	return
+}
+func (r *rabbitMQClientPublishSuccessful) PublishOnExchangeWithHeaders(exchange string, payload []byte, headers map[string]interface{}) (err error) {
+	if exchange != r.ExpectedPublishExchange {
+		r.t.Fatal("expected", r.ExpectedPublishExchange, "got", exchange)
+	}
+
+	if !reflect.DeepEqual(payload, r.ExpectedPublishPayload) {
+		r.t.Fatal("expected", string(r.ExpectedPublishPayload), "got", string(payload))
+	}
+	if fmt.Sprintf("%+v", headers) != fmt.Sprintf("%+v", r.ExpectedHeaders) {
+		r.t.Fatal("expected headers", fmt.Sprintf("%+v", r.ExpectedHeaders), "got", fmt.Sprintf("%+v", headers))
+	}
+
+	return
+}
 
 type rabbitMQClientPublishError struct{}
 
@@ -70,6 +96,12 @@ func (r *rabbitMQClientPublishError) Publish(routingKey string, payload []byte) 
 	return fmt.Errorf("Publish error")
 }
 func (r *rabbitMQClientPublishError) PublishOnExchange(exchange string, payload []byte) error {
+	return fmt.Errorf("Publish error")
+}
+func (r *rabbitMQClientPublishError) PublishWithHeaders(string, []byte, map[string]interface{}) error {
+	return fmt.Errorf("Publish error")
+}
+func (r *rabbitMQClientPublishError) PublishOnExchangeWithHeaders(string, []byte, map[string]interface{}) error {
 	return fmt.Errorf("Publish error")
 }
 

--- a/monitor/checker/rabbitmq_test.go
+++ b/monitor/checker/rabbitmq_test.go
@@ -24,6 +24,14 @@ func (c *testConn) PublishOnExchange(exchange string, payload []byte) error {
 	return nil
 }
 
+func (c *testConn) PublishWithHeaders(string, []byte, map[string]interface{}) error {
+	return nil
+}
+
+func (c *testConn) PublishOnExchangeWithHeaders(string, []byte, map[string]interface{}) error {
+	return nil
+}
+
 func (c *testConn) Consume() error {
 	return nil
 }


### PR DESCRIPTION
This PR introduces support for Setting headers when publishing messages on queue/exchange, and also allows reading header(s) from our AMQPDelivery abstraction.

The AMQPDelivery also allows setting a custom header. The purpose of this is to possibly enable us to set redeliveries=N type of headers before requeueing a msg. I've intentionally narrowed down the contract to only allow string values as headers values instead of string => interface{} key value pairs. This simplifies client usage of this library, eliminating the need for type-checking.

The PR contains some simple unit tests. I've also tested these changes in a separate PR in Coulomb (from where this requirement originates)

Note that I'm not 100% happy about adding two more "Publish..." functions to this library. However, since Go doesn't allow for overloaded function names, this is probably the least ugly approach. In a future MAJOR release, we could consider making a breaking change where all 4 "Publish..." functions are  replaced by a single Publish(routingKey, exchange string, payload []byte, headers map[string]interface{}) one.