### PR TITLE
Added option to skip declare of exchange

### DIFF
--- a/amqp/queue/rabbitmq.go
+++ b/amqp/queue/rabbitmq.go
@@ -76,6 +76,8 @@ type RabbitMQExchange struct {
 	Internal bool
 	// see streadway docs
 	NoWait bool
+	// to avoid redeclaring an already existing exchange, set this to true.
+	SkipDeclare bool
 	// if true, create a companion dead-letter exchange
 	AutoDLE bool
 }

--- a/amqp/rabbitmq.go
+++ b/amqp/rabbitmq.go
@@ -26,18 +26,19 @@ type RabbitMQClient struct {
 // Connect takes care of "on connect" specific tasks. Queue(s) and Exchange(s) may be created on the fly given the queues
 // specified in the slice of RabbitMQQueue.
 //
-// q.Exchange - if not nil, an exchange will be created. If AutoDLE is true, a corresponding dead-letter exchange is created as well.
-// q.AutoDLQ - if true, a DLQ with bindings will be created for the queue specified in q.Name.
+// q.Exchange - if not nil and SkipDeclare is false, an exchange will be created. If AutoDLE is true, a corresponding
+// dead-letter exchange is created as well.
+// q.AutoDLQ - if true, a DLQ with bindings will be created for the queue specified in q.Name. If AutoDLQ is true, a
+// corresponding dead-letter queue is created as well.
 func (c *RabbitMQClient) Connect() error {
 	for _, q := range c.Cfg.Queues {
 		if q.SkipDeclare {
 			c.Log.Info(fmt.Sprintf("Skipping declaration of queue: %s", q.Name))
-
 			continue
 		}
 
-		// Declare exchange and DLE if an exchange is specified
-		if q.Exchange != nil {
+		// Declare exchange and DLE if an exchange is specified and SkipDeclare is false
+		if q.Exchange != nil && !q.Exchange.SkipDeclare {
 			err := c.declareExchange(q.Exchange)
 			if err != nil {
 				return err


### PR DESCRIPTION
In cases where we have several queues to be defined belonging to the same exchange (e.g. fanout with no routing-key), we should have an option to explicitly skip declare of the exchange.

This allows for example set up of:

"myexchange" -> "queue1"
"myexchange" -> "queue2"

without having to carefully make sure the definition of "queue2" uses exactly the same arguments for the exchange as "queue1".

Note that I havn't unit-tested this since the low-level amqp.Channel required to first create a queue is basically non-mockable since it's a struct and not an interface.